### PR TITLE
Fix the hyperlinks in CERN's JIRA sprint boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Open the following links in new tabs to install each individual userscripts. `Ta
 - [Gitlab (auto-collapse threads on resolve)](https://github.com/7PH/userscript-gitlab-auto-collapse-threads/raw/master/gitlab-auto-collapse-threads.user.js)
 - [EDH Absence Planning Fix (show month labels, auto-select start of the week, auto-submit on first page load)](https://github.com/7PH/cern-userscripts/raw/refs/heads/master/src/edh.cern.ch/fix-absence-overview.user.js)
 - [JIRA (move comment input near the latest comment)](https://github.com/7PH/cern-userscripts/raw/refs/heads/master/src/its.cern.ch/jira-fix-comment-input.user.js)
+- [JIRA (clicking an issue title in a sprint board will open the issue in a new tab instead of the side panel)](https://github.com/7PH/cern-userscripts/raw/refs/heads/master/src/its.cern.ch/jira-fix-links.user.js)

--- a/src/its.cern.ch/jira-fix-links.user.js
+++ b/src/its.cern.ch/jira-fix-links.user.js
@@ -1,0 +1,63 @@
+// ==UserScript==
+// @name         Fix hyperlinks in JIRA sprint boards
+// @namespace    https://github.com/7PH
+// @version      0.0.1
+// @description  Fixes hyperlinks in JIRA sprint boards.
+// @author       7PH (https://github.com/7PH)
+// @match        https://its.cern.ch/jira/secure/RapidBoard.jspa?rapidView=*
+// @icon         https://www.google.com/s2/favicons?sz=64&domain=cern.ch
+// @grant        none
+// @homepage     https://github.com/7PH/cern-userscripts
+// @homepageURL  https://github.com/7PH/cern-userscripts
+// @source       https://github.com/7PH/cern-userscripts
+// @supportURL   https://github.com/7PH/cern-userscripts/issues
+// @updateURL    https://raw.githubusercontent.com/7PH/cern-userscripts/master/src/its.cern.ch/jira-fix-links.user.js
+// @downloadURL  https://raw.githubusercontent.com/7PH/cern-userscripts/master/src/its.cern.ch/jira-fix-links.user.js
+// ==/UserScript==
+
+(async function() {
+    'use strict';
+
+    const SELECTORS = {
+        issueBlock: '.js-issue',
+        issueBlockTitle: '.js-issue a.js-key-link',
+    };
+
+    const SELECTOR_POLLING_DELAY_MS = 100;
+
+    async function sleepFor(durationMs) {
+        return new Promise(resolve => setTimeout(resolve, durationMs));
+    }
+
+    async function waitForSelector(selector) {
+        const elements = document.querySelectorAll(selector);
+        if (elements.length === 0) {
+            await sleepFor(SELECTOR_POLLING_DELAY_MS);
+            return waitForSelector(selector);
+        }
+        return elements;
+    }
+
+    function overrideClickEvent(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        window.open(event.target.closest('a').href);
+        return false;
+    }
+
+    async function applyFix() {
+        const issueTitles = await waitForSelector(SELECTORS.issueBlockTitle);
+        for (const issueTitle of issueTitles) {
+            if (issueTitle.dataset.fixed) {
+                // return;
+            }
+            issueTitle.addEventListener("click", overrideClickEvent);
+            issueTitle.dataset.fixed = "true";
+        }
+    }
+
+    applyFix();
+
+    const observer = new MutationObserver(applyFix);
+    observer.observe(document.body, { childList: true, subtree: true });
+})();


### PR DESCRIPTION
Clicking an issue title in a JIRA Sprint board should open the issue in a new window, **not** open the side panel. The side panel can still be opened by clicking anywhere else on the issue.