### PR TITLE
Set more specific match URL for the fix-leave-request.user.js

### DIFF
--- a/src/edh.cern.ch/fix-leave-request.user.js
+++ b/src/edh.cern.ch/fix-leave-request.user.js
@@ -4,7 +4,7 @@
 // @version      1.2.0
 // @description  Adds a big half-day calendar to the EDH Absence Request (LVRQ) form. Paint Annual Leave / Teleworking on half-days; the calendar is kept in two-way sync with the "Absence periods" rows.
 // @author       Dariusz Zielinski
-// @match        https://edh.cern.ch/*
+// @match        https://edh.cern.ch/Document/Claims/LeaveRequest
 // @noframes
 // @grant        none
 // @run-at       document-idle


### PR DESCRIPTION
No need to load the script on every EDH page. There's a specific URL for leave requests.